### PR TITLE
Update go.rb to go1.21.0

### DIFF
--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,20 +3,20 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://golang.org/'
-  version '1.20.1'
+  version '1.21.0'
   license 'BSD'
   compatibility 'all'
   source_url({
-    aarch64: 'https://go.dev/dl/go1.20.1.linux-armv6l.tar.gz',
-     armv7l: 'https://go.dev/dl/go1.20.1.linux-armv6l.tar.gz',
-       i686: 'https://go.dev/dl/go1.20.1.linux-386.tar.gz',
-     x86_64: 'https://go.dev/dl/go1.20.1.linux-amd64.tar.gz'
+    aarch64: 'https://go.dev/dl/go1.21.0.linux-arm64.tar.gz',
+     armv7l: 'https://go.dev/dl/go1.21.0.linux-armv6l.tar.gz',
+       i686: 'https://go.dev/dl/go1.21.0.linux-386.tar.gz',
+     x86_64: 'https://go.dev/dl/go1.21.0.linux-amd64.tar.gz'
   })
   source_sha256({
-    aarch64: 'e4edc05558ab3657ba3dddb909209463cee38df9c1996893dd08cde274915003',
-     armv7l: 'e4edc05558ab3657ba3dddb909209463cee38df9c1996893dd08cde274915003',
-       i686: '3a7345036ebd92455b653e4b4f6aaf4f7e1f91f4ced33b23d7059159cec5f4d7',
-     x86_64: '000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02'
+    aarch64: 'f3d4548edf9b22f26bbd49720350bbfe59d75b7090a1a2bff1afad8214febaf3',
+     armv7l: 'e377a0004957c8c560a3ff99601bce612330a3d95ba3b0a2ae144165fc87deb1',
+       i686: '0e6f378d9b072fab0a3d9ff4d5e990d98487d47252dba8160015a61e6bd0bcba',
+     x86_64: 'd0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742'
   })
 
   no_compile_needed


### PR DESCRIPTION
Fixes #

<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->

## Description
<!--
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.
-->

update golang to latest version: 1.21.0
reference: https://go.dev/dl/

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/yougg/chromebrew.git CREW_TESTING_BRANCH=golang CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->

and run:

```shell
crew upgrade
```
![Screenshot 2023-08-10 19 37 04](https://github.com/yougg/chromebrew/assets/1641020/7e3469b6-fd15-4e37-8717-d3b5decb8af6)

